### PR TITLE
Addition of popmax allele freq. to gnomad annotations

### DIFF
--- a/cancermuts/datasources.py
+++ b/cancermuts/datasources.py
@@ -1231,7 +1231,7 @@ class gnomAD(DynamicSource, object):
         for md in md_type:
             if md not in self._version_metadata_compatability[self._gnomad_version]:
                 self.log.error(f"The  metadata type '{md}' is not compatible with the gnomAD version. Compatible metadata are {self._version_metadata_compatability[self._gnomad_version]}")
-                raise ValueError
+                raise ValueError(f"The  metadata type '{md}' is not compatible with the gnomAD version. Compatible metadata are {self._version_metadata_compatability[self._gnomad_version]}")
        
         if use_alias is not None:
             gene_id = sequence.aliases[use_alias]

--- a/cancermuts/metadata.py
+++ b/cancermuts/metadata.py
@@ -371,6 +371,23 @@ class gnomADGenomeAlleleFrequency(gnomADAlleleFrequency):
         return "<gnomADGenomeAlleleFrequency, %f>" % self.frequency
 
 class gnomADPopmaxExomeAlleleFrequency(gnomADAlleleFrequency):
+    """This class represents gnomad popmax exome allele frequency
+
+    Attributes
+    ----------
+    basic_description : :obj:`str`
+        string containing description of the frequency type
+    description : :obj:`str`
+        string containing description of the frequency type including gnomad version
+    freq_type : :obj:`str``
+        string containing the type of allele frequency
+    get_value : :obj:`cancermuts.metadata.gnomADAlleleFrequency.get_value`
+        gets the frequency from self
+    get_value_str : :obj:`cancermuts.metadata.gnomADAlleleFrequency.get_value_str`
+        gets the frequency from self and converts it to string
+    header : :obj:`str``
+        string containing the name of the column header for the metatable
+    """
 
     freq_type = "Popmax exome"
     basic_description = "%s allele frequency" % freq_type
@@ -379,15 +396,54 @@ class gnomADPopmaxExomeAlleleFrequency(gnomADAlleleFrequency):
 
     @classmethod
     def set_version_in_desc(cls, version_string):
+        """Makes it possible to use the class for different versions
+
+        Parameters
+        ----------
+        version_string
+        """
         cls.description = "%s (%s)" % (cls.basic_description, version_string)
 
     def __init__(self, source, frequency):
+        """Constructor for the gnomAD popmax exome allele frequency
+
+        Parameters
+        ----------
+        source: :obj:`cancermuts.datasources.gnomAD`
+            Object containing the source of the frequency
+        version_string: 'str'
+            String containing the gnomAD version
+        """
         super(gnomADPopmaxExomeAlleleFrequency, self).__init__(source, frequency)
 
     def __repr__(self):
+        """Function which creates the string to add to the mutation object
+
+        Returns
+        -------
+        'str'
+            String containing allele frequency type and the corresponding frequency.
+        """
         return "<gnomADPopmaxExomeAlleleFrequency, %f>" % self.frequency
 
 class gnomADPopmaxGenomeAlleleFrequency(gnomADAlleleFrequency):
+    """This class represents gnomad popmax genome allele frequency
+
+    Attributes
+    ----------
+    basic_description : :obj:`str`
+        string containing description of the frequency type
+    description : :obj:`str`
+        string containing description of the frequency type including gnomad version
+    freq_type : :obj:`str``
+        string containing the type of allele frequency
+    get_value : :obj:`cancermuts.metadata.gnomADAlleleFrequency.get_value`
+        gets the frequency from self
+    get_value_str : :obj:`cancermuts.metadata.gnomADAlleleFrequency.get_value_str`
+        gets the frequency from self and converts it to string
+    header : :obj:`str``
+        string containing the name of the column header for the metatable
+    """
 
     freq_type = "Popmax genome"
     basic_description = "%s allele frequency" % freq_type
@@ -396,12 +452,34 @@ class gnomADPopmaxGenomeAlleleFrequency(gnomADAlleleFrequency):
 
     @classmethod
     def set_version_in_desc(cls, version_string):
+        """Makes it possible to use the class for different versions
+
+        Parameters
+        ----------
+        version_string
+        """
         cls.description = "%s (%s)" % (cls.basic_description, version_string)
 
     def __init__(self, source, frequency):
+        """Constructor for the gnomAD popmax exome allele frequency
+
+        Parameters
+        ----------
+        source: :obj:`cancermuts.datasources.gnomAD`
+            Object containing the source of the frequency
+        version_string: 'str'
+            String containing the gnomAD version
+        """
         super(gnomADPopmaxGenomeAlleleFrequency, self).__init__(source, frequency)
 
     def __repr__(self):
+        """Function which creates the string to add to the mutation object
+
+        Returns
+        -------
+        'str'
+            String containing allele frequency type and the corresponding frequency.
+        """
         return "<gnomADPopmaxGenomeAlleleFrequency, %f>" % self.frequency
 
 class CancerSite(Metadata):

--- a/cancermuts/metadata.py
+++ b/cancermuts/metadata.py
@@ -370,6 +370,40 @@ class gnomADGenomeAlleleFrequency(gnomADAlleleFrequency):
     def __repr__(self):
         return "<gnomADGenomeAlleleFrequency, %f>" % self.frequency
 
+class gnomADPopmaxExomeAlleleFrequency(gnomADAlleleFrequency):
+
+    freq_type = "Popmax exome"
+    basic_description = "%s allele frequency" % freq_type
+    description = basic_description
+    header = "gnomad_popmax_exome_af"
+
+    @classmethod
+    def set_version_in_desc(cls, version_string):
+        cls.description = "%s (%s)" % (cls.basic_description, version_string)
+
+    def __init__(self, source, frequency):
+        super(gnomADPopmaxExomeAlleleFrequency, self).__init__(source, frequency)
+
+    def __repr__(self):
+        return "<gnomADPopmaxExomeAlleleFrequency, %f>" % self.frequency
+
+class gnomADPopmaxGenomeAlleleFrequency(gnomADAlleleFrequency):
+
+    freq_type = "Popmax genome"
+    basic_description = "%s allele frequency" % freq_type
+    description = basic_description
+    header = "gnomad_popmax_genome_af"
+
+    @classmethod
+    def set_version_in_desc(cls, version_string):
+        cls.description = "%s (%s)" % (cls.basic_description, version_string)
+
+    def __init__(self, source, frequency):
+        super(gnomADPopmaxGenomeAlleleFrequency, self).__init__(source, frequency)
+
+    def __repr__(self):
+        return "<gnomADPopmaxGenomeAlleleFrequency, %f>" % self.frequency
+
 class CancerSite(Metadata):
 
     description = "Cancer site"
@@ -442,6 +476,8 @@ metadata_classes = {
                      'revel_score'                 : DbnsfpRevel,
                      'gnomad_genome_allele_frequency' : gnomADGenomeAlleleFrequency,
                      'gnomad_exome_allele_frequency' : gnomADExomeAlleleFrequency,
+                     'gnomad_popmax_genome_allele_frequency' : gnomADPopmaxGenomeAlleleFrequency,
+                     'gnomad_popmax_exome_allele_frequency' : gnomADPopmaxExomeAlleleFrequency,
                      'cancer_site'                 : CancerSite,
                      'cancer_histology'            : CancerHistology,
                    }

--- a/cancermuts/metadata.py
+++ b/cancermuts/metadata.py
@@ -435,13 +435,13 @@ class gnomADPopmaxGenomeAlleleFrequency(gnomADAlleleFrequency):
         string containing description of the frequency type
     description : :obj:`str`
         string containing description of the frequency type including gnomad version
-    freq_type : :obj:`str``
+    freq_type : :obj:`str`
         string containing the type of allele frequency
     get_value : :obj:`cancermuts.metadata.gnomADAlleleFrequency.get_value`
         gets the frequency from self
     get_value_str : :obj:`cancermuts.metadata.gnomADAlleleFrequency.get_value_str`
         gets the frequency from self and converts it to string
-    header : :obj:`str``
+    header : :obj:`str`
         string containing the name of the column header for the metatable
     """
 

--- a/cancermuts/properties.py
+++ b/cancermuts/properties.py
@@ -1,5 +1,6 @@
     # metadata.py - properties handling for the cancermuts package
 # (c) 2018 Matteo Tiberti <matteo.tiberti@gmail.com>
+# (c) 2023 Katrine Meldgård <katrine@meldgaard.dk>
 # This file is part of cancermuts
 #
 # cancermuts is free software: you can redistribute it and/or modify

--- a/cancermuts/table.py
+++ b/cancermuts/table.py
@@ -176,7 +176,7 @@ class Table:
 
 
 
-    def to_dataframe(self, sequence, mutation_metadata=["cancer_study", "cancer_type", "genomic_coordinates", "genomic_mutations", "revel_score", "cancer_site", "cancer_histology",'gnomad_exome_allele_frequency', 'gnomad_genome_allele_frequency'], 
+    def to_dataframe(self, sequence, mutation_metadata=["cancer_study", "cancer_type", "genomic_coordinates", "genomic_mutations", "revel_score", "cancer_site", "cancer_histology",'gnomad_exome_allele_frequency', 'gnomad_genome_allele_frequency','gnomad_popmax_exome_allele_frequency', 'gnomad_popmax_genome_allele_frequency'], 
                         position_properties=['ptm_phosphorylation','ptm_methylation','ptm_ubiquitination','ptm_cleavage', 'ptm_nitrosylation','ptm_acetylation', 'ptm_sumoylation', 'ptm_ogalnac', 'ptm_oglcnac', 'mobidb_disorder_propensity'],
                         sequence_properties=['linear_motif', 'structure']):
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -415,26 +415,34 @@ the two scores we are able to gather have the same value.
 #### gnomAD allele frequencies
 
 Similarly, we annotate mutations with their exome or genome allele frequencies
-as found in the [gnomAD database](https://www.gnomad.org). This works as you 
-would expect by now:
+as found in the [gnomAD database](https://www.gnomad.org). It is also possible to
+annotate with the highest allele frequency found in non-bottlenecked 
+populations (referred to as popmax). This works as you would expect by now:
 
 ```py
 >>> from cancermuts.datasources import gnomAD
 
 >>> gnomad = gnomAD(version='2.1')
 >>> gnomad.add_metadata(seq, md_type=['gnomad_exome_allele_frequency',
-	                              'gnomad_genome_allele_frequency'])
+	                              'gnomad_genome_allele_frequency',
+                                  'gnomad_popmax_exome_allele_frequency',
+	                              'gnomad_popmax_genome_allele_frequency'])
 ```
 
 here, we specify the `version` argument to specify the version of gnomAD to be 
 considered. Please refer to the API documentation for all the available versions.
 
 The `md_type` keyword allows to select which metadata type(s) to annotate, i.e.
-choose between exome or allele frequency (or both as in the example).
+choose between exome or genome allele frequency (or both as in the example) and whether 
+to annotate the popmax as well. Note, that they can all be chosen independently 
+of each other.
 
 We calculate the allele frequency as the ratio between the total allele count over
 the allele number as found in gnomAD, if the entry for the corresponding variant 
 is available.
+
+The popmax allele frequency is found by calculating the exome and/or genome allele frequency from 
+all supported non-bottlenecked populations and then finding the maximum frequency of those.
 
 Finally we can check the downloaded metadata:
 


### PR DESCRIPTION
fixes #146. Adds popmax allele frequencies to the mutation object in the same way that allele frequencies are added. 