### PR TITLE
in GenomicMutation metadata, makes HGVS definition check stricter

### DIFF
--- a/cancermuts/metadata.py
+++ b/cancermuts/metadata.py
@@ -142,8 +142,8 @@ class GenomicMutation(Metadata):
 
     allowed_bases = set(['A', 'C', 'G', 'T'])
 
-    _mut_snv_regexp = '^[0-9XY]+:g\.[0-9]+[ACTG]>[ACTG]'
-    _mut_insdel_regexp = '^[0-9XY]+:g\.[0-9]+_[0-9]+delins[ACTG]+'
+    _mut_snv_regexp = '^[0-9XY]+:g\.[0-9]+[ACTG]>[ACTG]$'
+    _mut_insdel_regexp = '^[0-9XY]+:g\.[0-9]+_[0-9]+delins[ACTG]+$'
     _mut_snv_prog = re.compile(_mut_snv_regexp)
     _mut_insdel_prog = re.compile(_mut_insdel_regexp)
     _mut_snv_parse = '{chr}:g.{coord:d}{ref:l}>{alt:l}'
@@ -200,6 +200,7 @@ class GenomicMutation(Metadata):
             self.definition = f"{self.chr}:g.{self.coord_start}_{self.coord_end}delins{self.substitution}"
 
         else:
+            self.log.info("doing other")
             self.chr = None
             self.coord = None
             self.ref = None

--- a/cancermuts/metadata.py
+++ b/cancermuts/metadata.py
@@ -158,10 +158,6 @@ class GenomicMutation(Metadata):
 
         if self._mut_snv_prog.match(definition):
             tokens = parse(self._mut_snv_parse, definition)
-            if tokens['ref'] not in self.allowed_bases or \
-               tokens['alt'] not in self.allowed_bases:
-                self.log.error(f'this mutation does not specify allowed nucleotides: {definition}')
-                return None
 
             if tokens['chr'] == '23':
                 self.chr = 'X'
@@ -180,9 +176,6 @@ class GenomicMutation(Metadata):
 
         elif self._mut_insdel_prog.match(definition):
             tokens = parse(self._mut_insdel_parse, definition)
-            if not set(tokens['substitution']).issubset(self.allowed_bases):
-                self.log.error(f'this mutation does not specify allowed nucleotides: {definition}')
-                return None
 
             if tokens['chr'] == '23':
                 self.chr = 'X'


### PR DESCRIPTION
An erroneously annotated delins (like `T>TAG`) was being classified as SNV but did not complete the annotation because of the broken HGVS format. I have fixed the problem by making the SNV regex stricter and removing (at that point) not useful checks