### PR TITLE
Adding safeguard for cBioPortal when non-canonical isoform is used

### DIFF
--- a/cancermuts/datasources.py
+++ b/cancermuts/datasources.py
@@ -336,12 +336,12 @@ class cBioPortal(DynamicSource, object):
         _cBioPortal_supported_metadata = ['cancer_type', 'cancer_study', 'genomic_coordinates', 'genomic_mutations']
 
         if not sequence.is_canonical:
-            raise UnexpectedIsoformError("cBioPortal mutation annotation only supports canonical isoforms. Please use a canonical UniProt sequence")
+            raise UnexpectedIsoformError("cBioPortal mutation annotation only supports canonical isoforms. Please use a Sequence object for a canonical isoform")
 
         if 'entrez' not in sequence.aliases.keys() or sequence.aliases['entrez'] is None:
             self.log.error('Entrez ID alias not available in sequence object')
             raise TypeError('Entrez ID alias not available in sequence object')
-        
+
         for md in metadata:
             if md not in _cBioPortal_supported_metadata:
                 self.log.error(f'{md} is not a valid metadata. Supported metadata are: {_cBioPortal_supported_metadata}')

--- a/cancermuts/datasources.py
+++ b/cancermuts/datasources.py
@@ -337,6 +337,9 @@ class cBioPortal(DynamicSource, object):
         if 'entrez' not in sequence.aliases.keys() or sequence.aliases['entrez'] is None:
             self.log.error('Entrez ID alias not available in sequence object')
             raise TypeError('Entrez ID alias not available in sequence object')
+        
+        if hasattr(sequence, "is_canonical") and not sequence.is_canonical:
+            raise ValueError("cBioPortal mutation annotation only supports canonical isoforms.")
 
         for md in metadata:
             if md not in _cBioPortal_supported_metadata:

--- a/cancermuts/datasources.py
+++ b/cancermuts/datasources.py
@@ -339,8 +339,8 @@ class cBioPortal(DynamicSource, object):
             self.log.error('Entrez ID alias not available in sequence object')
             raise TypeError('Entrez ID alias not available in sequence object')
         
-        if hasattr(sequence, "is_canonical") and not sequence.is_canonical:
-            raise UnexpectedIsoformError("cBioPortal mutation annotation only supports canonical isoforms.")
+        if not sequence.is_canonical:
+            raise UnexpectedIsoformError("cBioPortal mutation annotation only supports canonical isoforms. Please use a canonical UniProt sequence")
 
         for md in metadata:
             if md not in _cBioPortal_supported_metadata:

--- a/cancermuts/datasources.py
+++ b/cancermuts/datasources.py
@@ -335,13 +335,13 @@ class cBioPortal(DynamicSource, object):
     def add_mutations(self, sequence, metadata=[]):
         _cBioPortal_supported_metadata = ['cancer_type', 'cancer_study', 'genomic_coordinates', 'genomic_mutations']
 
+        if not sequence.is_canonical:
+            raise UnexpectedIsoformError("cBioPortal mutation annotation only supports canonical isoforms. Please use a canonical UniProt sequence")
+
         if 'entrez' not in sequence.aliases.keys() or sequence.aliases['entrez'] is None:
             self.log.error('Entrez ID alias not available in sequence object')
             raise TypeError('Entrez ID alias not available in sequence object')
         
-        if not sequence.is_canonical:
-            raise UnexpectedIsoformError("cBioPortal mutation annotation only supports canonical isoforms. Please use a canonical UniProt sequence")
-
         for md in metadata:
             if md not in _cBioPortal_supported_metadata:
                 self.log.error(f'{md} is not a valid metadata. Supported metadata are: {_cBioPortal_supported_metadata}')

--- a/cancermuts/datasources.py
+++ b/cancermuts/datasources.py
@@ -38,6 +38,7 @@ from .core import Sequence, Mutation
 from .properties import *
 from .metadata import *
 from .log import *
+from .exceptions import UnexpectedIsoformError
 from io import StringIO
 import json
 import re
@@ -339,7 +340,7 @@ class cBioPortal(DynamicSource, object):
             raise TypeError('Entrez ID alias not available in sequence object')
         
         if hasattr(sequence, "is_canonical") and not sequence.is_canonical:
-            raise ValueError("cBioPortal mutation annotation only supports canonical isoforms.")
+            raise UnexpectedIsoformError("cBioPortal mutation annotation only supports canonical isoforms.")
 
         for md in metadata:
             if md not in _cBioPortal_supported_metadata:

--- a/cancermuts/exceptions.py
+++ b/cancermuts/exceptions.py
@@ -1,0 +1,3 @@
+class UnexpectedIsoformError(Exception):
+    """Raised when a non-canonical isoform is used in a context that requires the canonical sequence."""
+    pass

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -120,11 +120,11 @@ the canonical UniProt isoform will be used. Notice that, currently, only some
 data sources support alternative isoform; those that do not support them will
 raise exceptions if a Sequence object containing an alternative isoform is provided to them.
 In this case we provide an example which use a non-canonical isoform as input in the 
-`tutorial_isoforms.py` file. It's run in the same way as with the other 
+`tutorial_alternative_isoforms.py` file. It's run in the same way as with the other 
 tutorial scripts:
 
 ```
-$ python tutorial_isoforms.py
+$ python tutorial_alternative_isoforms.py
 ```
 It loads a specific AMBRA1 isoform (since LC3B lacks characterized non-canonical isoforms) and 
 ends after successfully downloading and displaying the isoform sequence.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -111,7 +111,7 @@ $ python tutorial_pancancer.py
 Similarly as before, the result should be a `metatable_pancancer.csv` output file
 together with a `my_table_pancancer.pdf` figure.
 
-### Isoform tutorial
+### Alternative isoform tutorial
 
 Cancermuts allows requesting alternative isoforms, if available in UniProt.
 To request a specific isoform, provide a isoform ID, in the form of a UniProt isoform
@@ -126,7 +126,7 @@ tutorial scripts:
 ```
 $ python tutorial_isoforms.py
 ```
-It loads a specific AMBRA1 isoform (here we use AMBRA1 because LC3B has not-main isoforms) and 
+It loads a specific AMBRA1 isoform (since LC3B lacks characterized non-canonical isoforms) and 
 ends after successfully downloading and displaying the isoform sequence.
 
 ## Tutorial steps

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -76,6 +76,8 @@ the gathered information.
 
 ## Tutorial script
 
+### Canonical isoform tutorial
+
 The steps performed in the following tutorial are also written in a pre-built
 Python script available in the `docs` folder, called `tutorial.py`. In order
 to run it, you should have installed the Cancermuts package and activated the
@@ -108,6 +110,24 @@ $ python tutorial_pancancer.py
 
 Similarly as before, the result should be a `metatable_pancancer.csv` output file
 together with a `my_table_pancancer.pdf` figure.
+
+### Isoform tutorial
+
+Cancermuts allows requesting alternative isoforms, if available in UniProt.
+To request a specific isoform, provide a isoform ID, in the form of a UniProt isoform
+identifier, to the isoform argument, as in the following example. If this is not done,
+the canonical UniProt isoform will be used. Notice that, currently, only some
+data sources support alternative isoform; those that do not support them will
+raise exceptions if a Sequence object containing an alternative isoform is provided to them.
+In this case we provide an example which use a non-canonical isoform as input in the 
+`tutorial_isoforms.py` file. It's run in the same way as with the other 
+tutorial scripts:
+
+```
+$ python tutorial_isoforms.py
+```
+It loads a specific AMBRA1 isoform (here we use AMBRA1 because LC3B has not-main isoforms) and 
+ends after successfully downloading and displaying the isoform sequence.
 
 ## Tutorial steps
 
@@ -148,15 +168,6 @@ MPSEKTFKQRRTFEQRVEDVRLIREQHPTKIPVIIERYKGEKQLPVLDKTKFLVPDHVNMSELIKIIRRRLQLNANQAFF
 >>> seq.positions[0:3]
 
 ```
-
-### Optional: Requesting a specific isoform
-
-Cancermuts allows requesting alternative isoforms, if available in UniProt.
-To request a specific isoform, provide a isoform ID, in the form of a UniProt isoform
-identifier, to the isoform argument, as in the following example. If this is not done,
-the canonical UniProt isoform will be used. Notice that, currently, only some
-data sources support alternative isoform; those that do not support them will
-raise exceptions if a Sequence object containing an alternative isoform is provided to them.
 
 ```py
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -121,7 +121,7 @@ data sources support alternative isoform; those that do not support them will
 raise exceptions if a Sequence object containing an alternative isoform is provided to them.
 In this case we provide an example which use a non-canonical isoform as input in the 
 `tutorial_alternative_isoforms.py` file. It's run in the same way as with the other 
-tutorial scripts:
+tutorial script:
 
 ```
 $ python tutorial_alternative_isoforms.py

--- a/docs/tutorial.py
+++ b/docs/tutorial.py
@@ -5,10 +5,10 @@ from cancermuts.datasources import UniProt
 up = UniProt()
 
 # get the sequence for the protein
- seq = up.get_sequence('MAP1LC3B')
+seq = up.get_sequence('MAP1LC3B')
 
 # alternatively, we can specifically ask for a Uniprot ID
- seq = up.get_sequence('MAP1LC3B', upid='MLP3B_HUMAN')
+seq = up.get_sequence('MAP1LC3B', upid='MLP3B_HUMAN')
 
 # OPTIONAL: Use a specific UniProt isoform instead of canonical
 # seq = up.get_sequence("AMBRA1", isoform='Q9C0C7-2')
@@ -22,6 +22,7 @@ seq.positions[0:3]
 
 # import data sources classes
 from cancermuts.datasources import cBioPortal, COSMIC
+from cancermuts.exceptions import UnexpectedIsoformError
 
 # add mutations from cBioPortal
 
@@ -31,7 +32,7 @@ cb = cBioPortal(cancer_studies=['coadread_dfci_2016',
 
 try:
     cb.add_mutations(seq, metadata=['cancer_type', 'cancer_study', 'genomic_mutations'])
-except ValueError as e:
+except UnexpectedIsoformError as e:
     print(f"cBioPortal error: {e}")
 
 # let us check out some of the mutations

--- a/docs/tutorial.py
+++ b/docs/tutorial.py
@@ -5,13 +5,13 @@ from cancermuts.datasources import UniProt
 up = UniProt()
 
 # get the sequence for the protein
-seq = up.get_sequence('MAP1LC3B')
+#seq = up.get_sequence('MAP1LC3B')
 
 # alternatively, we can specifically ask for a Uniprot ID
-seq = up.get_sequence('MAP1LC3B', upid='MLP3B_HUMAN')
+#seq = up.get_sequence('MAP1LC3B', upid='MLP3B_HUMAN')
 
 # OPTIONAL: Use a specific UniProt isoform instead of canonical
-# seq = up.get_sequence("AMBRA1", isoform='Q9C0C7-2')
+seq = up.get_sequence("AMBRA1", isoform='Q9C0C7-2')
 
 
 # this prints the downloaded protein sequence
@@ -29,18 +29,22 @@ cb = cBioPortal(cancer_studies=['coadread_dfci_2016',
 	                            'coadread_genentech',
 	                            'coadread_tcga_pan_can_atlas_2018'])
 
-cb.add_mutations(seq, metadata=['cancer_type', 'cancer_study', 'genomic_mutations'])
+try:
+    cb.add_mutations(seq, metadata=['cancer_type', 'cancer_study', 'genomic_mutations'])
+except ValueError as e:
+    print(f"cBioPortal error: {e}")
 
 # let us check out some of the mutations
-print(seq.positions[38].mutations)
-print(seq.positions[64].mutations)
-print(seq.positions[122].mutations)
+try:
+    print(seq.positions[38].mutations)
+    print(seq.positions[64].mutations)
+    print(seq.positions[122].mutations)
 
-print(seq.positions[64].mutations[0].sources)
-
-print(seq.positions[64].mutations[0].mutated_residue_type)
-
-print(seq.positions[38].mutations[0].metadata)
+    print(seq.positions[64].mutations[0].sources)
+    print(seq.positions[64].mutations[0].mutated_residue_type)
+    print(seq.positions[38].mutations[0].metadata)
+except (IndexError, AttributeError) as e:
+    print(f"Could not display cBioPortal mutations: {e}")
 
 
 # add mutations from COSMIC

--- a/docs/tutorial.py
+++ b/docs/tutorial.py
@@ -5,13 +5,13 @@ from cancermuts.datasources import UniProt
 up = UniProt()
 
 # get the sequence for the protein
-#seq = up.get_sequence('MAP1LC3B')
+ seq = up.get_sequence('MAP1LC3B')
 
 # alternatively, we can specifically ask for a Uniprot ID
-#seq = up.get_sequence('MAP1LC3B', upid='MLP3B_HUMAN')
+ seq = up.get_sequence('MAP1LC3B', upid='MLP3B_HUMAN')
 
 # OPTIONAL: Use a specific UniProt isoform instead of canonical
-seq = up.get_sequence("AMBRA1", isoform='Q9C0C7-2')
+# seq = up.get_sequence("AMBRA1", isoform='Q9C0C7-2')
 
 
 # this prints the downloaded protein sequence

--- a/docs/tutorial.py
+++ b/docs/tutorial.py
@@ -10,10 +10,6 @@ seq = up.get_sequence('MAP1LC3B')
 # alternatively, we can specifically ask for a Uniprot ID
 seq = up.get_sequence('MAP1LC3B', upid='MLP3B_HUMAN')
 
-# OPTIONAL: Use a specific UniProt isoform instead of canonical
-# seq = up.get_sequence("AMBRA1", isoform='Q9C0C7-2')
-
-
 # this prints the downloaded protein sequence
 print(seq.sequence)
 
@@ -22,7 +18,6 @@ seq.positions[0:3]
 
 # import data sources classes
 from cancermuts.datasources import cBioPortal, COSMIC
-from cancermuts.exceptions import UnexpectedIsoformError
 
 # add mutations from cBioPortal
 
@@ -30,23 +25,16 @@ cb = cBioPortal(cancer_studies=['coadread_dfci_2016',
 	                            'coadread_genentech',
 	                            'coadread_tcga_pan_can_atlas_2018'])
 
-try:
-    cb.add_mutations(seq, metadata=['cancer_type', 'cancer_study', 'genomic_mutations'])
-except UnexpectedIsoformError as e:
-    print(f"cBioPortal error: {e}")
+cb.add_mutations(seq, metadata=['cancer_type', 'cancer_study', 'genomic_mutations'])
 
 # let us check out some of the mutations
-try:
-    print(seq.positions[38].mutations)
-    print(seq.positions[64].mutations)
-    print(seq.positions[122].mutations)
+print(seq.positions[38].mutations)
+print(seq.positions[64].mutations)
+print(seq.positions[122].mutations)
 
-    print(seq.positions[64].mutations[0].sources)
-    print(seq.positions[64].mutations[0].mutated_residue_type)
-    print(seq.positions[38].mutations[0].metadata)
-except (IndexError, AttributeError) as e:
-    print(f"Could not display cBioPortal mutations: {e}")
-
+print(seq.positions[64].mutations[0].sources)
+print(seq.positions[64].mutations[0].mutated_residue_type)
+print(seq.positions[38].mutations[0].metadata)
 
 # add mutations from COSMIC
 cosmic = COSMIC(database_files=['/data/databases/cosmic-v96/CosmicMutantExport.tsv'],

--- a/docs/tutorial_alternative_isoforms.py
+++ b/docs/tutorial_alternative_isoforms.py
@@ -1,5 +1,6 @@
 # import the UniProt data source class
-from cancermuts.datasources import UniProt
+from cancermuts.datasources import UniProt, cBioPortal
+from cancermuts.exceptions import *
 
 # create the UniProt object
 up = UniProt()
@@ -14,5 +15,13 @@ print(seq.sequence)
 print(seq.positions[0:5])
 
 # confirm non-canonical status
-print("Is canonical?", seq.is_canonical)
+print("Is the sequence canonical?", seq.is_canonical)
+
+# cBioPortal does not support non-canonical mutations
+cbioportal = cBioPortal()
+
+try:
+    cbioportal.add_mutations(seq)
+except UnexpectedIsoformError:
+    print("cBioPortal mutations will not be added, as a non-canonical isoform has been provided")
 

--- a/docs/tutorial_alternative_isoforms.py
+++ b/docs/tutorial_alternative_isoforms.py
@@ -13,6 +13,6 @@ print(seq.sequence)
 # the seq.positions attribute is an ordered list of the protein positions:
 print(seq.positions[0:5])
 
-# confirm canonical status
+# confirm non-canonical status
 print("Is canonical?", seq.is_canonical)
 

--- a/docs/tutorial_isoforms.py
+++ b/docs/tutorial_isoforms.py
@@ -1,0 +1,18 @@
+# import the UniProt data source class
+from cancermuts.datasources import UniProt
+
+# create the UniProt object
+up = UniProt()
+
+# retrieve a specific UniProt isoform
+seq = up.get_sequence("AMBRA1", isoform="Q9C0C7-2")
+
+# this prints the downloaded isoform sequence
+print(seq.sequence)
+
+# the seq.positions attribute is an ordered list of the protein positions:
+print(seq.positions[0:5])
+
+# confirm canonical status
+print("Is canonical?", seq.is_canonical)
+

--- a/docs/tutorial_pancancer.py
+++ b/docs/tutorial_pancancer.py
@@ -21,14 +21,17 @@ seq.positions[0:3]
 
 # import data sources classes
 from cancermuts.datasources import cBioPortal, COSMIC
+from cancermuts.exceptions import UnexpectedIsoformError
 
 # add mutations from cBioPortal
 
-cb = cBioPortal()
+cb = cBioPortal(cancer_studies=['coadread_dfci_2016',
+                                'coadread_genentech',
+                                'coadread_tcga_pan_can_atlas_2018'])
 
 try:
     cb.add_mutations(seq, metadata=['cancer_type', 'cancer_study', 'genomic_mutations'])
-except ValueError as e:
+except UnexpectedIsoformError as e:
     print(f"cBioPortal error: {e}")
 
 # let us check out some of the mutations

--- a/docs/tutorial_pancancer.py
+++ b/docs/tutorial_pancancer.py
@@ -21,9 +21,7 @@ from cancermuts.datasources import cBioPortal, COSMIC
 
 # add mutations from cBioPortal
 
-cb = cBioPortal(cancer_studies=['coadread_dfci_2016',
-                                'coadread_genentech',
-                                'coadread_tcga_pan_can_atlas_2018'])
+cb = cBioPortal()
 
 cb.add_mutations(seq, metadata=['cancer_type', 'cancer_study', 'genomic_mutations'])
 

--- a/docs/tutorial_pancancer.py
+++ b/docs/tutorial_pancancer.py
@@ -10,9 +10,6 @@ seq = up.get_sequence('MAP1LC3B')
 # alternatively, we can specifically ask for a Uniprot ID
 seq = up.get_sequence('MAP1LC3B', upid='MLP3B_HUMAN')
 
-# OPTIONAL: Load a specific UniProt isoform instead of canonical
-# seq = up.get_sequence("AMBRA1", isoform='Q9C0C7-2')
-
 # this prints the downloaded protein sequence
 print(seq.sequence)
 
@@ -21,7 +18,6 @@ seq.positions[0:3]
 
 # import data sources classes
 from cancermuts.datasources import cBioPortal, COSMIC
-from cancermuts.exceptions import UnexpectedIsoformError
 
 # add mutations from cBioPortal
 
@@ -29,22 +25,16 @@ cb = cBioPortal(cancer_studies=['coadread_dfci_2016',
                                 'coadread_genentech',
                                 'coadread_tcga_pan_can_atlas_2018'])
 
-try:
-    cb.add_mutations(seq, metadata=['cancer_type', 'cancer_study', 'genomic_mutations'])
-except UnexpectedIsoformError as e:
-    print(f"cBioPortal error: {e}")
+cb.add_mutations(seq, metadata=['cancer_type', 'cancer_study', 'genomic_mutations'])
 
 # let us check out some of the mutations
-try:
-    print(seq.positions[38].mutations)
-    print(seq.positions[64].mutations)
-    print(seq.positions[122].mutations)
+print(seq.positions[38].mutations)
+print(seq.positions[64].mutations)
+print(seq.positions[122].mutations)
 
-    print(seq.positions[64].mutations[0].sources)
-    print(seq.positions[64].mutations[0].mutated_residue_type)
-    print(seq.positions[38].mutations[0].metadata)
-except (IndexError, AttributeError) as e:
-    print(f"Could not display cBioPortal mutations: {e}")
+print(seq.positions[64].mutations[0].sources)
+print(seq.positions[64].mutations[0].mutated_residue_type)
+print(seq.positions[38].mutations[0].metadata)
 
 
 # add mutations from COSMIC

--- a/docs/tutorial_pancancer.py
+++ b/docs/tutorial_pancancer.py
@@ -26,18 +26,22 @@ from cancermuts.datasources import cBioPortal, COSMIC
 
 cb = cBioPortal()
 
-cb.add_mutations(seq, metadata=['cancer_type', 'cancer_study', 'genomic_mutations'])
+try:
+    cb.add_mutations(seq, metadata=['cancer_type', 'cancer_study', 'genomic_mutations'])
+except ValueError as e:
+    print(f"cBioPortal error: {e}")
 
 # let us check out some of the mutations
-print(seq.positions[38].mutations)
-print(seq.positions[64].mutations)
-print(seq.positions[122].mutations)
+try:
+    print(seq.positions[38].mutations)
+    print(seq.positions[64].mutations)
+    print(seq.positions[122].mutations)
 
-print(seq.positions[64].mutations[0].sources)
-
-print(seq.positions[64].mutations[0].mutated_residue_type)
-
-print(seq.positions[38].mutations[0].metadata)
+    print(seq.positions[64].mutations[0].sources)
+    print(seq.positions[64].mutations[0].mutated_residue_type)
+    print(seq.positions[38].mutations[0].metadata)
+except (IndexError, AttributeError) as e:
+    print(f"Could not display cBioPortal mutations: {e}")
 
 
 # add mutations from COSMIC


### PR DESCRIPTION
fixes #43 subissue #209

Updated tutorial and datasources.py with a safeguard when using non-canonical isoform