### PR TITLE
Added condition in GenomicMutation to remove definition nans values

### DIFF
--- a/cancermuts/datasources.py
+++ b/cancermuts/datasources.py
@@ -1660,7 +1660,7 @@ class COSMIC(DynamicSource, object):
         if df.empty:
             self.log.warning(f"No COSMIC mutations for gene {gene_id} with TRANSCRIPT_ACCESSION={transcript_accession}; returning empty results")
             return [], out_metadata
-            
+
         if cancer_types is not None:
             df = df[ df['PRIMARY_HISTOLOGY'].isin(cancer_types) ]
         if cancer_histology_subtype_1 is not None:
@@ -1708,14 +1708,18 @@ class COSMIC(DynamicSource, object):
                 gd.append(r['MUTATION_CDS'][-3])
 
             if do_genomic_coordinates:
+                if pd.isna(gd).any():
+                    gd = None
+
                 out_metadata['genomic_coordinates'].append(gd)
 
             if do_genomic_mutations:
-                if gd is None:
+                if gd is None or pd.isna(r['HGVSG']):
                     self.log.warning("couldn't annotate genomic mutation")
                     gm = None
                 else:
                     gm = [gd[0], r['HGVSG']]
+
                 out_metadata['genomic_mutations'].append(gm)
 
             if do_site:

--- a/cancermuts/metadata.py
+++ b/cancermuts/metadata.py
@@ -156,7 +156,7 @@ class GenomicMutation(Metadata):
         self.genome_build = genome_build
         self.definition = definition
 
-        if self.definition == self.definition and self._mut_snv_prog.match(definition):
+        if self._mut_snv_prog.match(definition):
             tokens = parse(self._mut_snv_parse, definition)
 
             if tokens['chr'] == '23':
@@ -174,7 +174,7 @@ class GenomicMutation(Metadata):
 
             self.definition=f"{self.chr}:g.{self.coord}{self.ref}>{self.alt}"
 
-        elif self.definition == self.definition and self._mut_insdel_prog.match(definition):
+        elif self._mut_insdel_prog.match(definition):
             tokens = parse(self._mut_insdel_parse, definition)
 
             if tokens['chr'] == '23':


### PR DESCRIPTION
Found a solution to not parse `GenomicMutation` in the metadata if the `definition` of the genomic mutation is `nan`. After careful consideration of how the classes in `metadata.py` are structured- the solution exploits the `__eq__()` method to check if the `definition` value of the genomic mutation is `nan`. This should be a consistent with the other classes where `nan` values for other metadata type are removed. 
