### PR TITLE
Adjusted GenomicMutation class in metadata.py to handle 2bp inversion variants

### DIFF
--- a/cancermuts/metadata.py
+++ b/cancermuts/metadata.py
@@ -174,7 +174,7 @@ class GenomicMutation(Metadata):
             self.alt = tokens['alt']
             self.is_snv = True
             self.is_insdel = False
-            self.is_inv = False
+            self.is_inversion = False
 
             self.definition=f"{self.chr}:g.{self.coord}{self.ref}>{self.alt}"
 
@@ -193,7 +193,7 @@ class GenomicMutation(Metadata):
             self.substitution = tokens['substitution']
             self.is_snv = False
             self.is_insdel = True
-            self.is_inv = False
+            self.is_inversion = False
 
             self.definition = f"{self.chr}:g.{self.coord_start}_{self.coord_end}delins{self.substitution}"
 
@@ -212,7 +212,7 @@ class GenomicMutation(Metadata):
             self.substitution = None
             self.is_snv = False
             self.is_insdel = False
-            self.is_inv = True
+            self.is_inversion = True
 
             self.definition = f"{self.chr}:g.{self.coord_start}_{self.coord_end}inv"
 
@@ -224,7 +224,7 @@ class GenomicMutation(Metadata):
             self.alt = None
             self.is_snv = False
             self.is_insdel = False
-            self.is_inv = False
+            self.is_inversion = False
 
     def get_value_str(self, fmt='csv'):
         if fmt == 'csv':


### PR DESCRIPTION
This PR addresses issue #242 

Good protein for testing: **OR2W3, OR2W3_HUMAN, NP_001001957**

Fix I implemented:
In `metadata.py`, class `GenomicMutation` had been designed to handle delins or subsitution variants. Now I also incorporated handling of 2bp inversions that also result in 1 missense change in the protein.