### PR TITLE
Excluded irregular genomic annotations from clinvar metadata

### DIFF
--- a/cancermuts/datasources.py
+++ b/cancermuts/datasources.py
@@ -1452,17 +1452,23 @@ class ClinVar(DynamicSource, object):
                         out_metadata[rs_key].append(rs_dict[xml_key])
                     else:
                         out_metadata[rs_key].append(None)
-
+            valid_gms = []
+            for gm in data["genomic_annotations_obj"].values():
+                if gm.chr is None or not (gm.is_snv or gm.is_insdel or gm.is_inversion):
+                    self.log.warning(
+                        f"ClinVar ID {clinvar_id}: genomic annotation '{gm.definition}' for {gm.genome_build} "
+                        f"is not in the expected for missense variant format and will not be added to genomic metadata")
+                    continue
+                valid_gms.append(gm)
             if "genomic_mutations" in metadata:
-                out_metadata["genomic_mutations"].append(list(data["genomic_annotations_obj"].values()))
+                out_metadata["genomic_mutations"].append(valid_gms)
             if "genomic_coordinates" in metadata:
                 out_metadata["genomic_coordinates"].append([
-                [gm.genome_build, gm.chr,
-                 gm.coord if gm.is_snv else gm.coord_start,
-                 gm.coord if gm.is_snv else gm.coord_end,
-                 gm.ref if gm.is_snv else gm.substitution]
-                 for gm in data["genomic_annotations_obj"].values()
-                ])
+                    [gm.genome_build, gm.chr,
+                     gm.coord if gm.is_snv else gm.coord_start,
+                     gm.coord if gm.is_snv else gm.coord_end,
+                     gm.ref if gm.is_snv else gm.substitution]
+                    for gm in valid_gms])
             if "clinvar_variant_id" in metadata:
                 out_metadata["clinvar_variant_id"].append(clinvar_id)
 

--- a/cancermuts/metadata.py
+++ b/cancermuts/metadata.py
@@ -220,8 +220,11 @@ class GenomicMutation(Metadata):
             self.log.info("doing other")
             self.chr = None
             self.coord = None
+            self.coord_start = None
+            self.coord_end = None
             self.ref = None
             self.alt = None
+            self.substitution = None
             self.is_snv = False
             self.is_insdel = False
             self.is_inversion = False


### PR DESCRIPTION
PR that addresses #260 
This PR fixes a crash in ClinVar annotation caused by assembly-specific genomic entries that do not match any of the supported `GenomicMutation` patterns in `metadata.py` (SNV, inversion, insdel).

With this change, unsupported genomic annotations are skipped from the variant’s ClinVar genomic metadata, while valid annotations for the same variant are still kept.

**Example:** for ClinVar ID 703420 (NM_021980.4(OPTN):c.964G>A, p.Glu322Lys), the GRCh38 annotation `NC_000010.11:g.13124076G>A` is kept, while the GRCh37 annotation `NC_000010.10:g.13166076=` is not included in genomic_mutations / genomic_coordinates. 