### PR TITLE
Modified table class and adjusted core.py

### DIFF
--- a/cancermuts/core.py
+++ b/cancermuts/core.py
@@ -187,22 +187,26 @@ class Sequence(object):
 
     def properties_at_position(self, position, property_name=None):
         """
-        If property_name is provided, return a list of properties from that
-        property category.
-        If property_name is None, return a dictionary mapping
-        property categories to matching properties.
+        If property_name is provided, return a dict of properties mapped
+        to the property category.
+        If property_name is None, return all property categories with their
+        properties.
         """
 
         if property_name is not None:
+            if property_name not in sequence_properties_classes:
+                raise ValueError(f"Unknown property_name: {property_name}")
             if property_name not in self.properties:
-                return []
-            return [prop for prop in self.properties[property_name]
-                    if position in prop.positions]
+                properties_to_check = {property_name: []}
+            else:
+                properties_to_check = {property_name: self.properties[property_name]}
+        else:
+            properties_to_check = self.properties
 
         properties = {}
-        for this_property_name, props in self.properties.items():
+        for this_property_name, props in properties_to_check.items():
             matching_props = [prop for prop in props if position in prop.positions]
-            if len(matching_props) > 0:
+            if matching_props:
                 properties[this_property_name] = matching_props
         return properties
 
@@ -401,7 +405,7 @@ class VariantRegister:
         except KeyError:
             return False
 
-    def get_variant_table(self, variant_types=None, metadata=None, metadata_formatter=None):
+    def get_variant_table(self, variant_types=None, metadata=[], metadata_formatter=None):
         """
         Return a pandas DataFrame containing the ordered variants stored in the register.
 
@@ -411,20 +415,26 @@ class VariantRegister:
             Variant type to include in the output. If provided, only variants whose
             ``variant_type`` matches one of the specified values are returned.
             If None, all variants are included.
+        metadata : iterable of :obj:`str`, optional
+            Metadata fields to include as additional columns.
+        metadata_formatter : callable, optional
+            Function used to format metadata values before adding them to the table.
 
         Returns
         -------
         :obj:`pandas.DataFrame`
             DataFrame with one row per variant
         """
-        if metadata is None:
-            metadata = []
+
         variants = self._sorted_variants()
         if variant_types is not None:
             if isinstance(variant_types, str):
                 variant_types = {variant_types}
             else:
                 variant_types = set(variant_types)
+            invalid_var_types = variant_types - {"missense", "delins", "insertion", "deletion"}
+            if invalid_var_types:
+                raise ValueError(f"Invalid variant type(s): {invalid_var_types}")
             variants = [v for v in variants if v.variant_type in variant_types]
 
         variant_dictionary = {"variant_hgvs": [],
@@ -436,7 +446,7 @@ class VariantRegister:
                               "sources": []}
 
         for md in metadata:
-                variant_dictionary[md] = []
+            variant_dictionary[md] = []
 
         for v in variants:
             variant_dictionary["variant_hgvs"].append(v.hgvs)
@@ -446,14 +456,8 @@ class VariantRegister:
             variant_dictionary["variant_alt"].append(v.alt)
             variant_dictionary["variant_type"].append(v.variant_type)
 
-            source_names = []
-            for source in v.sources:
-                if source.name not in source_names:
-                    source_names.append(source.name)
-            if len(source_names) > 0:
-                variant_dictionary["sources"].append(",".join(source_names))
-            else:
-                variant_dictionary["sources"].append(None)
+            source_names = sorted({source.name for source in v.sources})
+            variant_dictionary["sources"].append(",".join(source_names) if source_names else None)
             for md in metadata:
                 if md in v.metadata:
                     values = v.metadata[md]

--- a/cancermuts/core.py
+++ b/cancermuts/core.py
@@ -185,6 +185,27 @@ class Sequence(object):
                     existing.metadata[k] = var.metadata[k]
                     self.log.debug("    metadata %s was added anew" % k)
 
+    def properties_at_position(self, position, property_name=None):
+        """
+        If property_name is provided, return a list of properties from that
+        property category.
+        If property_name is None, return a dictionary mapping
+        property categories to matching properties.
+        """
+
+        if property_name is not None:
+            if property_name not in self.properties:
+                return []
+            return [prop for prop in self.properties[property_name]
+                    if position in prop.positions]
+
+        properties = {}
+        for this_property_name, props in self.properties.items():
+            matching_props = [prop for prop in props if position in prop.positions]
+            if len(matching_props) > 0:
+                properties[this_property_name] = matching_props
+        return properties
+
 class ProteinVariant(object):
     """This class describes in-frame protein variants on a reference sequence.
 
@@ -380,7 +401,7 @@ class VariantRegister:
         except KeyError:
             return False
 
-    def get_variant_table(self, variant_types=None):
+    def get_variant_table(self, variant_types=None, metadata=None, metadata_formatter=None):
         """
         Return a pandas DataFrame containing the ordered variants stored in the register.
 
@@ -396,29 +417,50 @@ class VariantRegister:
         :obj:`pandas.DataFrame`
             DataFrame with one row per variant
         """
-
+        if metadata is None:
+            metadata = []
         variants = self._sorted_variants()
         if variant_types is not None:
             if isinstance(variant_types, str):
                 variant_types = {variant_types}
             else:
                 variant_types = set(variant_types)
-
             variants = [v for v in variants if v.variant_type in variant_types]
 
-        variant_dictionary = {"variant": [],
+        variant_dictionary = {"variant_hgvs": [],
+                              "variant_start": [],
+                              "variant_end": [],
+                              "variant_ref": [],
+                              "variant_alt": [],
                               "variant_type": [],
-                              "position": [],
-                              "end": [],
-                              "ref": [],
-                              "alt": []}
+                              "sources": []}
+
+        for md in metadata:
+                variant_dictionary[md] = []
 
         for v in variants:
-            variant_dictionary["position"].append(v.start)
-            variant_dictionary["end"].append(v.end)
-            variant_dictionary["ref"].append(v.ref)
-            variant_dictionary["alt"].append(v.alt)
+            variant_dictionary["variant_hgvs"].append(v.hgvs)
+            variant_dictionary["variant_start"].append(v.start)
+            variant_dictionary["variant_end"].append(v.end)
+            variant_dictionary["variant_ref"].append(v.ref)
+            variant_dictionary["variant_alt"].append(v.alt)
             variant_dictionary["variant_type"].append(v.variant_type)
-            variant_dictionary["variant"].append(str(v))
+
+            source_names = []
+            for source in v.sources:
+                if source.name not in source_names:
+                    source_names.append(source.name)
+            if len(source_names) > 0:
+                variant_dictionary["sources"].append(",".join(source_names))
+            else:
+                variant_dictionary["sources"].append(None)
+            for md in metadata:
+                if md in v.metadata:
+                    values = v.metadata[md]
+                else:
+                    values = None
+                if metadata_formatter is not None:
+                    values = metadata_formatter(values, md)
+                variant_dictionary[md].append(values)
 
         return pd.DataFrame(variant_dictionary)

--- a/cancermuts/table.py
+++ b/cancermuts/table.py
@@ -222,8 +222,10 @@ class Table:
     def _ptm_sources_at_position(self, sequence, position):
         ptm_sources_list = []
         for ptm_key in self.ptms.keys():
-            for prop in sequence.properties_at_position(position, ptm_key):
-                ptm_sources_list.extend([s.name for s in prop.sources])
+            properties_at_pos = sequence.properties_at_position(position, ptm_key)
+            if ptm_key in properties_at_pos:
+                for prop in properties_at_pos[ptm_key]:
+                    ptm_sources_list.extend([s.name for s in prop.sources])
         ptm_sources_str = ",".join(sorted(set(ptm_sources_list))) if ptm_sources_list else None
         return ptm_sources_str
 
@@ -254,7 +256,11 @@ class Table:
             row = [position, residue]
 
             for property_name in sequence_properties:
-                properties = sequence.properties_at_position(position, property_name)
+                properties_at_pos = sequence.properties_at_position(position, property_name)
+                if property_name in properties_at_pos:
+                    properties = properties_at_pos[property_name]
+                else:
+                    properties = []
                 row.append(self._format_property_values(properties))
                 if property_name == 'ptm_glycosylation':
                     row.append(self._format_glycosylation_subtypes(properties))

--- a/cancermuts/table.py
+++ b/cancermuts/table.py
@@ -150,7 +150,7 @@ class Table:
         ptms = {}
         ptm_codes = {}
 
-        for k,v in iteritems(position_properties_classes):
+        for k,v in iteritems(sequence_properties_classes):
             headers[k] = v.header
             if 'ptm' in v.category:
                 ptms[k] = v.header
@@ -158,15 +158,16 @@ class Table:
 
         headers['ptm_sources'] = 'ptm_sources'
 
-        for k,v in iteritems(sequence_properties_classes):
-            headers[k] = v.header
-
         for k,v in iteritems(metadata_classes):
             headers[k] = v.header
 
-        headers['position']    = SequencePosition.header
-        headers['wt']          = 'ref_aa'
-        headers['mutated']     = 'alt_aa'
+        headers['position'] = 'aa_position'
+        headers['variant_hgvs'] = 'variant_hgvs'
+        headers['variant_start'] = 'variant_start'
+        headers['variant_end'] = 'variant_end'
+        headers['variant_type'] = 'variant_type'
+        headers['wt'] = 'ref_aa'
+        headers['mutated'] = 'alt_aa'
         headers['mut_sources'] = 'sources'
 
         self.headers = headers
@@ -176,157 +177,124 @@ class Table:
         if not set(self.ptms.keys()).issubset(set(self.ptm_colors.keys())):
             self.log.warning("not enough colors specified for ptms to plot")
 
+    def _format_metadata_values(self, values, metadata_key):
+        if values is None:
+            return None
+        md_values = []
+        for single_md in values:
+            if single_md is None:
+                continue
+            this_value = single_md.get_value_str()
+            if this_value is None or this_value != this_value:  # hacky check for np.nan
+                continue
+            md_values.append(this_value)
+        if "clinvar" in str(metadata_key):
+            if "condition" in str(metadata_key):
+                md_str = "|".join(map(str, md_values))
+            else:
+                md_str = ", ".join(map(str, md_values))
+        else:
+            md_str = ", ".join(sorted(set(map(str, md_values))))
+        return md_str
 
+    def _format_property_values(self, properties):
+        values = []
+        for prop in properties:
+            value = prop.get_value_str()
+            if value is None or value != value:
+                continue
+            if value not in values:
+                values.append(value)
+        if len(values) == 0:
+            return None
+        return "|".join(map(str, values))
 
-    def to_dataframe(self, sequence, mutation_metadata=["cancer_study", "cancer_type", "genomic_coordinates", "genomic_mutations", "revel_score", "cancer_site", "cancer_histology",'gnomad_exome_allele_frequency', 'gnomad_genome_allele_frequency',
-                                                        'gnomad_popmax_exome_allele_frequency', 'gnomad_popmax_genome_allele_frequency', 'clinvar_variant_id', 'clinvar_germline_classification', 'clinvar_germline_condition', 'clinvar_germline_review_status',
-                                                        'clinvar_oncogenicity_classification', 'clinvar_oncogenicity_condition', 'clinvar_oncogenicity_review_status', 'clinvar_clinical_impact_classification', 'clinvar_clinical_impact_condition', 'clinvar_clinical_impact_review_status'],
-                        position_properties=['ptm_phosphorylation','ptm_methylation','ptm_ubiquitination','ptm_cleavage','ptm_nitrosylation','ptm_acetylation', 'ptm_sumoylation','ptm_glycosylation', 'mobidb_disorder_propensity'],
-                        sequence_properties=['linear_motif', 'structure']):
+    def _format_glycosylation_subtypes(self, properties):
+        subtypes = []
+        for prop in properties:
+            for subtype in prop.metadata["subtypes"]:
+                if subtype not in subtypes:
+                    subtypes.append(subtype)
+        if len(subtypes) == 0:
+            return None
+        return ", ".join(subtypes)
 
-        rows = []
+    def _ptm_sources_at_position(self, sequence, position):
+        ptm_sources_list = []
+        for ptm_key in self.ptms.keys():
+            for prop in sequence.properties_at_position(position, ptm_key):
+                ptm_sources_list.extend([s.name for s in prop.sources])
+        ptm_sources_str = ",".join(sorted(set(ptm_sources_list))) if ptm_sources_list else None
+        return ptm_sources_str
 
-        header =  [ self.headers['position'] ]
-        for p in position_properties:
-            header.append(self.headers[p])
-            if p == 'ptm_glycosylation':
+    def to_dataframe(self, sequence, mutation_metadata=['cancer_study', 'cancer_type', 'genomic_coordinates', 'genomic_mutations', 'revel_score', 'cancer_site', 'cancer_histology',
+                                                        'gnomad_exome_allele_frequency', 'gnomad_genome_allele_frequency',
+                                                        'gnomad_popmax_exome_allele_frequency', 'gnomad_popmax_genome_allele_frequency',
+                                                        'clinvar_variant_id', 'clinvar_germline_classification', 'clinvar_germline_condition', 'clinvar_germline_review_status',
+                                                        'clinvar_oncogenicity_classification', 'clinvar_oncogenicity_condition', 'clinvar_oncogenicity_review_status',
+                                                        'clinvar_clinical_impact_classification', 'clinvar_clinical_impact_condition', 'clinvar_clinical_impact_review_status'],
+                    sequence_properties=['ptm_phosphorylation', 'ptm_methylation', 'ptm_ubiquitination', 'ptm_cleavage', 'ptm_nitrosylation',
+                                         'ptm_acetylation', 'ptm_sumoylation', 'ptm_glycosylation',
+                                         'mobidb_disorder_propensity', 'linear_motif', 'structure']):
+
+        position_rows = []
+
+        mutation_metadata = list(mutation_metadata)
+        sequence_properties = list(sequence_properties)
+
+        position_header = [self.headers['position'], "_residue_ref"]
+        for property_name in sequence_properties:
+            position_header.append(self.headers[property_name])
+            if property_name == 'ptm_glycosylation':
+                position_header.append('glycosylation_subtype')
+
+        position_header.append(self.headers['ptm_sources'])
+
+        for position, residue in sequence:
+            row = [position, residue]
+
+            for property_name in sequence_properties:
+                properties = sequence.properties_at_position(position, property_name)
+                row.append(self._format_property_values(properties))
+                if property_name == 'ptm_glycosylation':
+                    row.append(self._format_glycosylation_subtypes(properties))
+            row.append(self._ptm_sources_at_position(sequence, position))
+            position_rows.append(row)
+
+        position_df = pd.DataFrame(position_rows, columns=position_header)
+        variant_df = sequence.variants.get_variant_table(metadata=mutation_metadata,
+                                                         metadata_formatter=self._format_metadata_values)
+
+        metadata_rename = {}
+        for md in mutation_metadata:
+            metadata_rename[md] = self.headers[md]
+        variant_df = variant_df.rename(columns=metadata_rename)
+        df = position_df.merge(variant_df, how='left',
+                                           left_on=self.headers['position'],
+                                           right_on=self.headers['variant_start'],
+                                           sort=False)
+
+        df[self.headers['wt']] = df['variant_ref']
+        df[self.headers['mutated']] = df['variant_alt']
+        df[self.headers['wt']] = df[self.headers['wt']].fillna(df["_residue_ref"])
+
+        header = [self.headers['position'],
+                  self.headers['wt'],
+                  self.headers['mutated'],
+                  self.headers['variant_hgvs'],
+                  self.headers['variant_start'],
+                  self.headers['variant_end'],
+                  self.headers['variant_type'],
+                  self.headers['mut_sources']]
+
+        for property_name in sequence_properties:
+            header.append(self.headers[property_name])
+            if property_name == 'ptm_glycosylation':
                 header.append('glycosylation_subtype')
-
-        header += [self.headers['ptm_sources']]
-        sequence_properties_cols_start = len(header)
-
-        header += [ self.headers[p] for p in sequence_properties ]
-        sequence_properties_col = list(range(sequence_properties_cols_start, len(header)))
-        header += [self.headers['wt'], self.headers['mutated'], self.headers['mut_sources']]
+        header.append(self.headers['ptm_sources'])
         for md in mutation_metadata:
             header.append(self.headers[md])
-
-        positions_mutlist = []
-
-        for gi,p in enumerate(sequence.positions):
-            base_row = [p.sequence_position]
-            ptm_sources_list = []
-            for r in position_properties:
-                if r in p.properties:
-                    val = p.properties[r].get_value_str()
-                else:
-                    val = None
-
-                base_row.append(val)
-
-                if r == "ptm_glycosylation":
-                    str_subtypes = None
-                    if r in p.properties:
-                        subtypes = p.properties["ptm_glycosylation"].metadata["subtypes"]
-                        if len(subtypes) > 0:
-                            str_subtypes = ", ".join(subtypes)
-                    base_row.append(str_subtypes)
-
-            ptm_sources_list = []
-            for ptm_key in self.ptms.keys():
-                if ptm_key in p.properties:
-                    ptm_sources_list.extend([s.name for s in p.properties[ptm_key].sources])
-
-            ptm_sources_str = ",".join(sorted(set(ptm_sources_list))) if ptm_sources_list else None
-            base_row.append(ptm_sources_str)
-            base_row.extend([None]*len(sequence_properties_col))
-            base_row.append(p.wt_residue_type)
-
-            mut_strings = [str(m) for m in p.mutations]
-            mut_strings_order = sorted(list(range(len(mut_strings))), key=mut_strings.__getitem__)
-
-            if len(mut_strings_order) == 0:
-                this_row = list(base_row)
-                this_row.append(None)
-                this_row.append(None)
-                this_row.extend([None]*len(mutation_metadata))
-                positions_mutlist.append(gi)
-                rows.append(this_row)
-                continue
-
-            for m in mut_strings_order:
-                this_row = list(base_row)
-                this_row.append(p.mutations[m].mutated_residue_type)
-                this_row.append(",".join([s.name for s in p.mutations[m].sources]))
-                for md in mutation_metadata:
-                    md_values = []
-                    try:
-                        self.log.info(f"mutation {p.mutations[m]}")
-                        for single_md in p.mutations[m].metadata[md]:
-                            if single_md is None:
-                                continue
-                            this_value = single_md.get_value_str()
-                            if this_value is None or this_value != this_value: # hacky check for np.nan
-                                continue
-                            md_values.append(this_value)
-                            self.log.info(f"appending {single_md.get_value_str()}")
-                        self.log.info(f"values to be joined {md}: {sorted(list(set(md_values)))}")
-                        if "clinvar" in str(md):
-                            if "condition" in str(md):
-                                md_str = "|".join(map(str, md_values))
-                            else:
-                                md_str = ", ".join(map(str, md_values))
-                        else:
-                            md_str = ", ".join(sorted(set(map(str, md_values))))
-                    except KeyError:
-                        md_str = None
-                    this_row.append(md_str)
-                positions_mutlist.append(gi)
-                rows.append(this_row)
-
-        df = pd.DataFrame(rows, columns=header)
-
-        this_col = df.pop(self.headers['wt'])
-        df.insert(1, self.headers['wt'], this_col)
-
-        this_col = df.pop(self.headers['mutated'])
-        df.insert(2, self.headers['mutated'], this_col)
-
-        positions = df[ self.headers['position'] ]
-
-        property_cols = dict()
-
-        properties_series = dict()
-
-        delenda = []
-        for pidx, property_name in enumerate(sequence_properties):
-            if property_name not in sequence.properties:
-                #property_cols[property_name] = [ None ] * len(positions)
-                delenda.append(property_name)
-                self.log.warning("property %s not found in data; it won't be annotated" % property_name)
-                continue
-            elif sequence.properties[property_name][0].category == 'linear_motif':
-                property_cols[property_name] = dict( [ (i, list()) for i in list(set(positions)) ] )
-            elif sequence.properties[property_name][0].category == 'structure':
-                property_cols[property_name] = dict( [ (i, list()) for i in list(set(positions)) ] )
-
-        for d in delenda:
-            sequence_properties.remove(d)
-
-        for pidx, property_name in enumerate(sequence_properties):
-            props = sequence.properties[property_name]
-            for p in props:
-                if p.category == 'linear_motif':
-                    for pos in p.positions:
-                        property_cols[property_name][pos.sequence_position].append(p.get_value_str())
-                if p.category == 'structure':
-                    for pos in p.positions:
-                        property_cols[property_name][pos.sequence_position].append(p.get_value_str())
-
-        for pidx, property_name in enumerate(sequence_properties):
-            properties_series[property_name] = []
-
-            if p.category == 'linear_motif':
-                for pos in positions:
-                    properties_series[property_name].append("|".join(property_cols[property_name][pos]))
-                df[self.headers[property_name]] = properties_series[property_name]
-
-            if p.category == 'structure':
-                for pos in positions:
-                    properties_series[property_name].append("|".join(property_cols[property_name][pos]))
-                df[self.headers[property_name]] = properties_series[property_name]
-
-        return df
+        return df[header]
 
     def _splice_metatable(self, df, section_size=100):
         # position ranges are left and right-inclusive
@@ -413,7 +381,17 @@ class Table:
         all_positions = sorted(list(set(df_m[self.headers['position']])))
         for p in all_positions:
             this_muts = df_m[df_m[self.headers['position']] == p]
-            this_muts_str = ", ".join(["%s%d%s" % tuple(v) for v in this_muts[[self.headers['wt'], self.headers['position'], self.headers['mutated']]].values])
+            labels = []
+            for _, row in this_muts.iterrows():
+                if self.headers['variant_hgvs'] in this_muts.columns:
+                    variant = row[self.headers['variant_hgvs']]
+                    if pd.notna(variant) and variant != "":
+                        labels.append(str(variant))
+                        continue
+                labels.append("%s%d%s" % (row[self.headers['wt']],
+                                          row[self.headers['position']],
+                                          row[self.headers['mutated']]))
+            this_muts_str = ", ".join(labels)
             ax.text(p, next(ladder), this_muts_str, horizontalalignment='center', verticalalignment='center')
 
         if revel_cutoff:


### PR DESCRIPTION
Addresses comment #268 
## Summary

This PR updates the `Table` class to work with the refactored package where sequence annotations are stored as `SequenceProperty` objects in `sequence.properties`, and variants are managed through `VariantRegister`.

## Changes

- Added `Sequence.properties_at_position()` in `core.py`
- Updated `Table.to_dataframe()` to build residue-level rows from `Sequence.__iter__()`.
- Retrieved sequence properties from `sequence.properties_at_position()`.
- Updated mutation table integration to use `sequence.variants.get_variant_table()`.
- Added variant-specific columns:
  - `variant_hgvs`
  - `variant_start`
  - `variant_end`
  - `variant_type`
- Kept variants anchored to `variant_start`.
- Added metadata/property formatting helpers