### PR TITLE
Isoform flag is used before exiting if there is more than one canonical id

### DIFF
--- a/cancermuts/datasources.py
+++ b/cancermuts/datasources.py
@@ -179,16 +179,8 @@ class UniProt(DynamicSource, object):
                         isoform_map[iso_id] = is_displayed
         except KeyError as e:
             raise ValueError(f"Missing expected field '{e.args[0]}' in ALTERNATIVE PRODUCTS for UniProt entry {this_upac}")
-
+        
         canonical_isoforms = [iso_id for iso_id, is_canonical in isoform_map.items() if is_canonical]
-
-        if len(canonical_isoforms) > 1:
-            raise RuntimeError(
-                f"More than one canonical isoform found for UniProt entry {this_upac}: "
-                f"{', '.join(canonical_isoforms)}"
-            )
-
-        canonical_isoform = canonical_isoforms[0] if canonical_isoforms else None
 
         if isoform is not None:
             self.log.info(f"Isoform requested: {isoform}")
@@ -200,6 +192,14 @@ class UniProt(DynamicSource, object):
             fasta_id = isoform
 
         else:
+            if len(canonical_isoforms) > 1:
+                raise RuntimeError(
+                    f"More than one canonical isoform ID found for UniProt entry {this_upac}: "
+                    f"{', '.join(canonical_isoforms)}. "
+                    f"Please specify one explicitly with the isoform argument.")
+
+            canonical_isoform = canonical_isoforms[0] if canonical_isoforms else None
+
             if canonical_isoform is not None:
                 isoform = canonical_isoform
                 is_canonical = True

--- a/cancermuts/datasources.py
+++ b/cancermuts/datasources.py
@@ -179,7 +179,7 @@ class UniProt(DynamicSource, object):
                         isoform_map[iso_id] = is_displayed
         except KeyError as e:
             raise ValueError(f"Missing expected field '{e.args[0]}' in ALTERNATIVE PRODUCTS for UniProt entry {this_upac}")
-        
+
         canonical_isoforms = [iso_id for iso_id, is_canonical in isoform_map.items() if is_canonical]
 
         if isoform is not None:


### PR DESCRIPTION
fix #269 Changed the order `datasources.py` so if isoform is provided and canoincal ids are more than one the program will not exit