### PR TITLE
Adding -1 to canonical isoforms for imporved GlyGen matching

### DIFF
--- a/cancermuts/datasources.py
+++ b/cancermuts/datasources.py
@@ -2226,10 +2226,18 @@ class GlyGen(StaticSource, object):
         if not sequence.is_canonical:
             raise UnexpectedIsoformError("GlyGen annotation only supports canonical isoforms. Please use a Sequence object for a canonical isoform")
         
-        protein_df = self.database_df[self.database_df['uniprotkb_canonical_ac'] == sequence.isoform]
+        glygen_isoform = sequence.isoform
+        if glygen_isoform is None:
+            glygen_isoform = f"{sequence.uniprot_ac}-1"
+            self.log.warning(f"No isoform identifier found for canonical sequence {sequence.uniprot_ac}. "
+                             f"GlyGen annotates canonical proteoforms as {glygen_isoform}, so this "
+                             f"identifier will be used for GlyGen matching only." )
+
+        protein_df = self.database_df[self.database_df['uniprotkb_canonical_ac'] == glygen_isoform].copy()
         if protein_df.empty:
             if sequence.uniprot_ac in self.database_df['src_xref_id'].values:
-                raise UnexpectedIsoformError('GlyGen contains this protein, but the requested isoform is not present')
+                raise UnexpectedIsoformError(f"GlyGen contains this protein, but the requested canonical "
+                    f"isoform {glygen_isoform} is not present")
             else:
                 return
 


### PR DESCRIPTION
fix #277 
Now we add -1 in case isoform is None due to not alternative products present in uniprot. So in case the identifier with -1 is present in GlyGen now we will annotate the data, issue a warning, and keep going instead of exiting