### PR TITLE
added safeguard in ClinVar data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ The project uses [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`
 
 ## [2.0.1] - 2026-07-15
 
-### Added
-### Changed
 ### Fixed
 
 - Changed ClinVar data source class to filter out genomic variants using unsupported genome assemblies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The project uses [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`
 ### Changed
 ### Fixed
 
+## [2.0.1] - 2026-07-15
+
+### Added
+### Changed
+### Fixed
+
+- Changed ClinVar data source class to filter out genomic variants using unsupported genome assemblies
+
 ## [2.0.0] - 2026-06-16
 
 ### Added

--- a/cancermuts/__init__.py
+++ b/cancermuts/__init__.py
@@ -16,4 +16,4 @@
 # along with Nome-Programma.  If not, see <http://www.gnu.org/licenses/>.
 
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/cancermuts/datasources.py
+++ b/cancermuts/datasources.py
@@ -632,6 +632,10 @@ class ClinVar(DynamicSource, object):
         'clinvar_germline_classification', 'clinvar_germline_condition', 'clinvar_germline_review_status', 'genomic_mutations',
         'clinvar_variant_id', 'genomic_coordinates', 'clinvar_oncogenicity_condition', 'clinvar_oncogenicity_classification',
         'clinvar_oncogenicity_review_status', 'clinvar_clinical_impact_condition', 'clinvar_clinical_impact_review_status', 'clinvar_clinical_impact_classification']
+
+    _supported_genome_builds = { "GRCh37" : "hg19",
+                                 "GRCh38" : "hg38" }
+
     @logger_init
     def __init__(self, ncbi_requests_per_second=2, ncbi_rate_limit_lock_file="/tmp/cancermuts_ncbi_rate_limit.lock", ncbi_api_key=None):
         description = "ClinVar mutation database"
@@ -1228,6 +1232,7 @@ class ClinVar(DynamicSource, object):
         """
         Parse ClinVar-style annotation strings into GenomicMutation objects.
 
+        - Filters out unsupported genome builds
         - Converts genome builds (GRCh38 → hg38, GRCh37 → hg19)
         - Handles both SNVs and indels
 
@@ -1246,11 +1251,11 @@ class ClinVar(DynamicSource, object):
             try:
                 genome_build, hgvs = ann.split(",")
 
-                # Normalize genome build
-                if genome_build == "GRCh38":
-                    genome_build = "hg38"
-                elif genome_build == "GRCh37":
-                    genome_build = "hg19"
+                try:
+                    genome_build = self._supported_genome_builds[genome_build]
+                except KeyError:
+                    self.log.warning(f"genomic variant with genome build {genome_build} was skipped")
+                    continue
 
                 # Extract just the part after 'NC_...:g.' (e.g., "123A>G" or "123_124delinsAA")
                 hgvs_match = re.search(r"NC_0*(\d+)\.\d+:g\.(.+)", hgvs)


### PR DESCRIPTION
fixes #291 - hotfix release

ELM is currently down so our tutorials don't run. 

This error is due to `ClinVar` only; `COSMIC` and `cBioPortal` already implement safeguards (I checked). To test this I have:

  - rerun tutorials using code in main branch using `ggetELM` instead of `ELM` and done the same with this branch - result is identical, so docs don't need updating
  - ran this for MSH2 which is the protein that originally caused this fail. We get the expected warning on standard output:
```
15/07/2026,12:58 WARNING [cancermuts.ClinVar]> genomic variant with genome build NCBI36 was skipped
15/07/2026,12:58 WARNING [cancermuts.ClinVar]> genomic variant with genome build NCBI36 was skipped
```

in the output csv file the corresponding mutation is now missing the NCBI36 mutation as expected and has the same gnomAD allele frequency as before:

```
1023,292,T,S,ClinVar,,,,,,,,,,,,,,,,"hg19,2:47641489-47641489, hg38,2:47414350-47414350","hg19,2:g.47641489A>T, hg38,2:g.47414350A>T",,,,0.0000278686827668,,,,126976,Conflicting classifications of pathogenicity,Hereditary nonpolyposis colorectal neoplasms;Hereditary cancer-predisposing syndrome;not specified;not provided;Lynch syndrome,1,,,,,,
```
