### PR TITLE
Fix UniProt alias error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The project uses [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`
 ### Added
 ### Changed
 ### Fixed
-- Improve error handling in `UniProt._get_aliases()` so unresolved aliases are returned as `None` entries instead of causing the entire function to return `None`.
+- Improve UniProt alias error handling by returning unresolved aliases as `None` entries and raising a `ValueError` when required alias conversions cannot be resolved.
 
 ## [2.1.0] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The project uses [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`
 ### Added
 ### Changed
 ### Fixed
+- Improve error handling in `UniProt._get_aliases()` so unresolved aliases are returned as `None` entries instead of causing the entire function to return `None`.
 
 ## [2.1.0] - 2026-07-16
 

--- a/cancermuts/datasources.py
+++ b/cancermuts/datasources.py
@@ -463,7 +463,7 @@ class UniProt(DynamicSource, object):
 
             if t_keyword is not None:
                 self.log.info('using extracted keyword %s to parse results' % t_keyword)
-                out[t] = results['to'].get(t_keyword)
+                out[t] = results['to'][t_keyword]
             else:
                 out[t] = results['to']
 

--- a/cancermuts/datasources.py
+++ b/cancermuts/datasources.py
@@ -247,6 +247,8 @@ class UniProt(DynamicSource, object):
         elif upid is not None:
             self.log.info("UniProt AC will be mapped from UniProt ID")
             this_upac = self._get_aliases(upid, ['UniProtKB_primaryAccession'])['UniProtKB_primaryAccession']
+            if this_upac is None:
+                raise ValueError(f"Could not resolve UniProt primary accession for {upid}")
         else:
             self.log.info("retrieving UniProt ID for human gene %s" % gene_id)
             try:
@@ -264,9 +266,12 @@ class UniProt(DynamicSource, object):
                 self.log.info("will use Uniprot ID %s" % this_upid)
 
             this_upac = self._get_aliases(this_upid, ['UniProtKB_primaryAccession'])['UniProtKB_primaryAccession']
-
+            if this_upac is None:
+                raise ValueError(f"Could not resolve UniProt primary accession for {this_upid}")
         if upid is None:
             this_upid = self._get_aliases(this_upac, ['UniProtKB_uniProtkbId'])['UniProtKB_uniProtkbId']
+            if this_upid is None:
+                raise ValueError(f"Could not resolve UniProt primary accession for {this_upac}")
         else:
             this_upid = upid
 

--- a/cancermuts/datasources.py
+++ b/cancermuts/datasources.py
@@ -271,7 +271,7 @@ class UniProt(DynamicSource, object):
         if upid is None:
             this_upid = self._get_aliases(this_upac, ['UniProtKB_uniProtkbId'])['UniProtKB_uniProtkbId']
             if this_upid is None:
-                raise ValueError(f"Could not resolve UniProt primary accession for {this_upac}")
+                raise ValueError(f"Could not resolve UniProt ID for accession {this_upac}")
         else:
             this_upid = upid
 

--- a/cancermuts/datasources.py
+++ b/cancermuts/datasources.py
@@ -429,13 +429,25 @@ class UniProt(DynamicSource, object):
                 t_keyword = None
                 t_query = t
             self.log.info("fetching alias, fr=%s, to=%s, query=%s" % (fr, t_query, gene_id))
-            responses = self._uniprot_service.mapping( fr = fr,
-                                                       to = t_query,
-                                                       query = gene_id )['results']
+
+            mapping_result = self._uniprot_service.mapping(
+                fr=fr,
+                to=t_query,
+                query=gene_id)
+
+            if mapping_result is None:
+                self.log.warning(
+                    f"UniProt mapping returned no response for {gene_id} "
+                    f"when requesting {t}")
+                out[t] = None
+                continue
+
+            responses = mapping_result.get('results', [])
 
             if len(responses) == 0:
                 self.log.warning(f"No {t} found for {gene_id}")
-                return None
+                out[t] = None
+                continue
 
             if len(responses) > 1:
                 self.log.warning(f"Multiple {t} found for {gene_id}. Found {t}: {', '.join(response['to'] for response in responses)}. No {t} will be assigned.")
@@ -446,7 +458,7 @@ class UniProt(DynamicSource, object):
 
             if t_keyword is not None:
                 self.log.info('using extracted keyword %s to parse results' % t_keyword)
-                out[t] = results['to'][t_keyword]
+                out[t] = results['to'].get(t_keyword)
             else:
                 out[t] = results['to']
 


### PR DESCRIPTION
fix #294 

This PR improves the error handling in `UniProt._get_aliases()`.

### Changes

- return a complete alias dictionary instead of returning `None` when an alias cannot be resolved
- return `None` for unresolved aliases while continuing to process the remaining requested aliases
- handle invalid responses from the UniProt mapping service more robustly
